### PR TITLE
Simplify with use of fragments

### DIFF
--- a/todos/lib/todos/repo.ex
+++ b/todos/lib/todos/repo.ex
@@ -1,27 +1,3 @@
 defmodule Todos.Repo do
   use Ecto.Repo, otp_app: :todos
-  @doc """
-### A simple means to execute raw sql
-Usage:
-```
-[record | _] = Todos.Repo.execute_and_load("SELECT * FROM todos WHERE id = $1", [1], User)
-record
-# => %Todo{...}
-```
-"""
-
-  @spec execute_and_load(String.t, map(), __MODULE__) :: __MODULE__
-  def execute_and_load(sql, params, model) do
-    Ecto.Adapters.SQL.query!(__MODULE__, sql, params)
-      |> load_into(model)
-  end
-
-  defp load_into(response, model) do
-    Enum.map response.rows, fn(row) ->
-      fields = Enum.reduce(Enum.zip(response.columns, row), %{}, fn({key, value}, map) ->
-        Map.put(map, key, value)
-      end)
-      Ecto.Schema.__load__(model, nil, nil, [], fields, &__MODULE__.__adapter__.load/2)
-    end
-  end
 end


### PR DESCRIPTION
The whole code can be widely simplified by use of Ecto fragments. No need for custom SQL or the `Repo.execute_or_load` function.

Fragments allow us to insert custom SQL parts into otherwise regular Ecto queries. We can use the levenshtein function using:

``` elixir
    from q in query,
      where: fragment("levenshtein(?, ?)", q.name, ^query_string)) < 5,
      order_by: fragment("levenshtein(?, ?)", q.name, ^query_string),
      limit: 10
```

But we can do even better! Since query syntax is based on macros, we can extend it with macros! Let's define a levenshtein function for the query syntax:

``` elixir
  defmacrop levenshtein(lhs, rhs) do
    quote do
      fragment("levenshtein(?, ?)", unquote(lhs), unquote(rhs))
    end
  end
```

We can then use it in our query:

``` elixir
  def fuzzy_name_search(query \\ Todo, query_string) do
    from q in query,
      where: levenshtein(q.name, ^query_string) < 5,
      order_by: levenshtein(q.name, ^query_string)
  end
```

We can then use it like this:

``` elixir
Todo.fuzzy_name_search("custom") |> Repo.all

# We also made our query composable
import Ecto.Query
Todo.fuzzy_name_search("custom") |> limit(10) |> Repo.all

def long_names(query \\ Todo) do
  from q in query, where: fragment("len(?)", t.name) > 5
end

Todo.long_names |> Todo.fuzzy_name_search("custom") |> limit(10) |> Repo.all
```
